### PR TITLE
Use non-breaking spaces near punctuation

### DIFF
--- a/the-codeless-code/fr-cdlm/case-1.txt
+++ b/the-codeless-code/fr-cdlm/case-1.txt
@@ -12,11 +12,11 @@ en contemplation devant un unique diagramme de flux de données,
 que le novice identifia comme étant d'un composant mineur de l’immense système que les moines avaient été engagés pour maintenir.
 Poliment, le novice demanda au maitre sur quoi il travaillait.
 
-Le maître lui répondit : « Il y a un défaut, et j'étudie la meilleure façon de le réparer. »
+Le maître lui répondit : « Il y a un défaut, et j'étudie la meilleure façon de le réparer. »
 
-Le novice dit :
-« Vous prêchez souvent l’importance de définir des priorités.
-Comment alors pouvez-vous vous laisser obséder par quelque chose d’aussi petit et insignifiant ? »
+Le novice dit :
+« Vous prêchez souvent l’importance de définir des priorités.
+Comment alors pouvez-vous vous laisser obséder par quelque chose d’aussi petit et insignifiant ? »
 
 Sans dire un mot, le maître leva son bâton et l’abattit avec force sur le pied gauche nu du novice, cassant son petit orteil.
 Le novice hurla de douleur et sortit en boitant du bureau.

--- a/the-codeless-code/fr-cdlm/case-10.txt
+++ b/the-codeless-code/fr-cdlm/case-10.txt
@@ -9,41 +9,41 @@ En l'espace d'un mois, les moines se retrouvèrent en guenilles et souffrants de
 De plus en plus de délais furent dépassés.
 L'abbé implora le maître Java de reconsidérer sa décision.
 
-« Très bien » dit le maître Java.
-« Chaque jeudi, faites-leur en plus mettre leurs vêtements et leurs chaussures au feu, et jeter leur riz et leur poisson à la rivière. »
+« Très bien » dit le maître Java.
+« Chaque jeudi, faites-leur en plus mettre leurs vêtements et leurs chaussures au feu, et jeter leur riz et leur poisson à la rivière. »
 
 L'abbé demanda quelle transgression son clan avait pu commettre pour mériter un tel châtiment.
 
-« Châtiment ? » dit le maître Java.
-« Ma seule intention était de les récompenser.
-Les moines de l'Emprunte d'Éléphant ne sont-ils pas fiers de leur indépendance et de leur autonomie ?
-Leur code me l'indique pourtant :
+« Châtiment ? » dit le maître Java.
+« Ma seule intention était de les récompenser.
+Les moines de l'Emprunte d'Éléphant ne sont-ils pas fiers de leur indépendance et de leur autonomie ?
+Leur code me l'indique pourtant :
 
-« Chacun d'entre eux a essentiellement écrit les mêmes Objets d'Accès aux Données et les mêmes Objets-Valeurs que ses voisins.
+« Chacun d'entre eux a essentiellement écrit les mêmes Objets d'Accès aux Données et les mêmes Objets-Valeurs que ses voisins.
 Chacun d'entre eux a élaboré ses propres utilitaires sur les chaînes et autres analyseurs de fichiers de configuration.
 Chacun d'entre eux s'est évertué à concevoir, implémenter, intégrer, tester, déboguer, réparer, et étendre ce qu'il aurait pu simplement reprendre de l'un de ses confrères.
 
-« Dois-je en déduire l'incompétence ?
+« Dois-je en déduire l'incompétence ?
 Alors il faut mettre au ban du monastère jusqu'au dernier des moines de l'Emprunte d'Éléphant.
 
-« Dois-je en déduire l'ignorance délibérée ?
+« Dois-je en déduire l'ignorance délibérée ?
 Alors la tradition exige qu'ils se fouettent aux orties, et qu'<i>ensuite</i> on les mette au ban.
 
-« Dois-je en déduire le mépris pour la préciosité du temps ?
+« Dois-je en déduire le mépris pour la préciosité du temps ?
 Si oui, les oubliettes attendent...
 
-« Mais non, » conclut le maître Java.
-« Je dois plutôt en déduire l'orgueil -- l'orgueil puisé dans la prétendue supériorité de son code sur celui de ses confrères.
+« Mais non, » conclut le maître Java.
+« Je dois plutôt en déduire l'orgueil -- l'orgueil puisé dans la prétendue supériorité de son code sur celui de ses confrères.
 L'orgueil est l'une des Quatre Graines de la Grandeur, et doit être encouragé.
-Que l'Emprunte d'Éléphant aiguise son talent aux ciseaux et au harpon, à l'aiguille et à la faux, jusqu'à ce que chaque moine puisse être aussi fier de ses beaux habits que de la prise dans son assiette ! »
+Que l'Emprunte d'Éléphant aiguise son talent aux ciseaux et au harpon, à l'aiguille et à la faux, jusqu'à ce que chaque moine puisse être aussi fier de ses beaux habits que de la prise dans son assiette ! »
 
-« Il ne restera plus beaucoup de temps pour coder, » observa l'abbé.
-« Et l'Empereur est très littéral dans son interprétation du mot /deadline/. »
+« Il ne restera plus beaucoup de temps pour coder, » observa l'abbé.
+« Et l'Empereur est très littéral dans son interprétation du mot /deadline/. »
 
 Le maître hocha la tête.
-« Le marchand récemment ruiné ne connaît que les affres de la perte.
+« Le marchand récemment ruiné ne connaît que les affres de la perte.
 Alors que le vieil hermite loue les vertus de l'austérité, et ne changera pas sa situation.
-Pourtant, ne sont-ils pas un seul et même homme, à quelques années d'intervalle ? »
+Pourtant, ne sont-ils pas un seul et même homme, à quelques années d'intervalle ? »
 
 Ainsi l'Emprunte d'Éléphant fut épargnée par deux fois puis corrigée.
 

--- a/the-codeless-code/fr-cdlm/case-11.txt
+++ b/the-codeless-code/fr-cdlm/case-11.txt
@@ -11,12 +11,12 @@ Quand l'annonce de cette mesure lui parvint, le maître Java envoya chercher les
 Son courrier promettait qu'ils lui seraient rendus la semaine suivante.
 Et ils le furent, dans deux cages de bambou de la conception du maître Java.
 
-Les barreaux de la première cage étaient écartées d'une empalmure ; l'oiseau s'était aisément envolé pendant le trajet.
+Les barreaux de la première cage étaient écartées d'une empalmure ; l'oiseau s'était aisément envolé pendant le trajet.
 
 Les barreaux de la seconde cage étaient si rapprochés que ni l'air ni la lumière ne passaient au travers.
 À l'intérieur, l'oiseau arriva mort.
 
-Attaché à chaque cage était un poème de la main du maître :
+Attaché à chaque cage était un poème de la main du maître :
 
     Le long de la route //
     de l'<i>air</i> au /cercueil/ //

--- a/the-codeless-code/fr-cdlm/case-12.txt
+++ b/the-codeless-code/fr-cdlm/case-12.txt
@@ -3,21 +3,21 @@ Title: Conséquences
 Lang: fr
 Translator: cdlm
 
-Trois jeunes moines -- un du [[Spider Clan|Clan de l'Araignée]], un du [[Laughing Monkey Clan|Singe Rieur]], et un de [[Elephant's Footprint|l'Emprunte d'Éléphant]] -- débattaient de quelle couche était la plus importante : la couche de présentation, la couche métier, ou la couche de persistance.
+Trois jeunes moines -- un du [[Spider Clan|Clan de l'Araignée]], un du [[Laughing Monkey Clan|Singe Rieur]], et un de [[Elephant's Footprint|l'Emprunte d'Éléphant]] -- débattaient de quelle couche était la plus importante : la couche de présentation, la couche métier, ou la couche de persistance.
 Ils décidèrent finalement de poser la question au maître Java.
 
-Le maître convoqua l'un des robustes jardiniers qui entretenaient les terres du temple, et lui donna instruction ainsi :
-« Rossez et bottez ces trois moines pendant une minute.
-Ensuite, vous pouvez continuer à les battre aussi longtemps que vous le désirez. »
+Le maître convoqua l'un des robustes jardiniers qui entretenaient les terres du temple, et lui donna instruction ainsi :
+« Rossez et bottez ces trois moines pendant une minute.
+Ensuite, vous pouvez continuer à les battre aussi longtemps que vous le désirez. »
 
 Le jardinier rossa les moines pendant sept bonnes minutes, puis s'inclina et s'en fut.
 
-« Maintenant, » dit le maître.
-« Qui porte la plus lourde responsabilité pour vos contusions aujourd'hui ?
-Moi-même, pour avoir commandé au jardinier ; le jardinier, pour les six minutes laissées à sa discrétion ; ou les poings et pieds du jardinier ?
-Mesurez votre réponse, ou je devrai l'appeler à nouveau. »
+« Maintenant, » dit le maître.
+« Qui porte la plus lourde responsabilité pour vos contusions aujourd'hui ?
+Moi-même, pour avoir commandé au jardinier ; le jardinier, pour les six minutes laissées à sa discrétion ; ou les poings et pieds du jardinier ?
+Mesurez votre réponse, ou je devrai l'appeler à nouveau. »
 
-Après un long moment, le moine du Clan de l'Araignée dit :
-« Le charpentier qui posa la première poutre de ce temple porte le blâme le plus lourd. »
+Après un long moment, le moine du Clan de l'Araignée dit :
+« Le charpentier qui posa la première poutre de ce temple porte le blâme le plus lourd. »
 
 Le maître fut satisfait.

--- a/the-codeless-code/fr-cdlm/case-13.txt
+++ b/the-codeless-code/fr-cdlm/case-13.txt
@@ -3,21 +3,21 @@ Title: Évolution
 Lang: fr
 Translator: cdlm
 
-Un novice étudia le code du maître Java{{*}} et adopta le style de celui-ci avec la plus grande précision :
+Un novice étudia le code du maître Java{{*}} et adopta le style de celui-ci avec la plus grande précision :
 les patrons de conception employés, les conventions de nommage des variables, le nombre d'espaces utilisé pour indenter chaque bloc imbriqué dans un autre.
 Même les commentaires étaient une impressionnante imitation du ton du maître.
 
 Lors de sa revue de code suivante, à la grande surprise du novice, le maître était extrêmement mécontent.
 
-« Mais, maître, » protesta l'étudiant.
-« J'ai suivi votre propre exemple au point-virgule près.
-Voyez, ceci est une classe que vous avez écrite il n'y a pas un mois :
-ne ressemble-t-elle pas à mon code comme deux gouttes d'eau ? »
+« Mais, maître, » protesta l'étudiant.
+« J'ai suivi votre propre exemple au point-virgule près.
+Voyez, ceci est une classe que vous avez écrite il n'y a pas un mois :
+ne ressemble-t-elle pas à mon code comme deux gouttes d'eau ? »
 
-« C'est bien là le problème, » rétorqua le maître furieux.
-« Hier j'étais stupide, il y a une semaine un idiot, et il y a un mois un imbécile.
+« C'est bien là le problème, » rétorqua le maître furieux.
+« Hier j'étais stupide, il y a une semaine un idiot, et il y a un mois un imbécile.
 Ne me montre pas de code que j'aurais pu écrire hier.
-Montre-moi du code tel que je l'écrirai demain. »
+Montre-moi du code tel que je l'écrirai demain. »
 
 {{*}} Probablement [[Banzen]].
 

--- a/the-codeless-code/fr-cdlm/case-14.txt
+++ b/the-codeless-code/fr-cdlm/case-14.txt
@@ -3,24 +3,24 @@ Title: Hello, World
 Lang: fr
 Translator: cdlm
 
-Lors de leur premier jour au temple, le maître Java posa les trois questions suivantes aux novices :
+Lors de leur premier jour au temple, le maître Java posa les trois questions suivantes aux novices :
 
-« Souvent, quand on apprend un nouveau langage ou une nouvelle bibliothèque, le premier programme qu'on écrit est /Hello, World/.
+« Souvent, quand on apprend un nouveau langage ou une nouvelle bibliothèque, le premier programme qu'on écrit est /Hello, World/.
 Le but est d'afficher ces mots d'une manière qui montre le fonctionnement attendu de la technologie.
 Une fois cela fait, le programme n'est plus jamais lancé.
 
-« Maintenant : pourquoi ce programme dit-il /bonjour/, mais pas /au revoir/ ?
+« Maintenant : pourquoi ce programme dit-il /bonjour/, mais pas /au revoir/ ?
 
-« Également : pourquoi dire bonjour au /monde/, alors que l'auditoire n'est qu'une pauvre âme qui jettera le programme une fois son premier cri poussé ?
+« Également : pourquoi dire bonjour au /monde/, alors que l'auditoire n'est qu'une pauvre âme qui jettera le programme une fois son premier cri poussé ?
 
-« Et aussi : pourquoi devrait-ce être des salutations, puisque personne n'y répondra ? »
+« Et aussi : pourquoi devrait-ce être des salutations, puisque personne n'y répondra ? »
 
 - - -
 
 //
 Dites-moi un mot qui signifie autant /bonjour/ qu'<i>au revoir</i> -- //
-n'est-ce pas ça le premier cri d'un enfant ? //
+n'est-ce pas ça le premier cri d'un enfant ? //
 //
 Trouvez-moi un sommet duquel on voie monde -- //
 dans quel œil, alors, se reflète chaque tigre, //
-ainsi que le désert de sable sans fin?
+ainsi que le désert de sable sans fin ?

--- a/the-codeless-code/fr-cdlm/case-15.txt
+++ b/the-codeless-code/fr-cdlm/case-15.txt
@@ -7,20 +7,20 @@ Illus.0.title: {hmff}… oui, bon, avec un œuf dur…
 Un novice était récemment arrivé du [[Temple of Three Stones|Temple de Trois Pierres]] où on n'utilisait que C.
 Il débutait en Java, et bientôt il tomba sur l'immutabilité des Strings.
 
-« Je souhaite seulement convertir le contenu de ce champ en casse mixte ! » se plaignit-il.
-« Mais cela implique la construction d'un StringBuffer, et ensuite d'une nouvelle String, avec plein de caractères recopiés à l'identique entre eux !
-Pourquoi au juste les String ont-elles été conçues ainsi ? »
+« Je souhaite seulement convertir le contenu de ce champ en casse mixte ! » se plaignit-il.
+« Mais cela implique la construction d'un StringBuffer, et ensuite d'une nouvelle String, avec plein de caractères recopiés à l'identique entre eux !
+Pourquoi au juste les String ont-elles été conçues ainsi ? »
 
-Une sœur expérimentée entendit cela, et lui suggéra :
-« Une pièce de bronze qui passe de main en main peut toujours être échangée le lendemain ; on ne peut pas en dire autant d'un œuf. »
+Une sœur expérimentée entendit cela, et lui suggéra :
+« Une pièce de bronze qui passe de main en main peut toujours être échangée le lendemain ; on ne peut pas en dire autant d'un œuf. »
 Le novice reçut l'illumination.
 
 Le novice se mit à rendre /toutes/ ses classes immuables.
-Pas une seule propriété ne pouvait être modifiée : une nouvelle instance devait être construite à chaque changement.
+Pas une seule propriété ne pouvait être modifiée : une nouvelle instance devait être construite à chaque changement.
 Ses constructeurs étaient quelquefois étonnamment longs et complexes.
 
-Le maître Java eut vent de ceci, et dit :
-« Qu'une forme d'œuf soit coulée en bronze, et donnée à la nonne pour son petit déjeuner. »
+Le maître Java eut vent de ceci, et dit :
+« Qu'une forme d'œuf soit coulée en bronze, et donnée à la nonne pour son petit déjeuner. »
 
 C'est ainsi que la nonne fut chargée de corriger le novice.
 

--- a/the-codeless-code/fr-cdlm/case-16.txt
+++ b/the-codeless-code/fr-cdlm/case-16.txt
@@ -5,21 +5,21 @@ Translator: cdlm
 
 Un abbé du [[Seven-Clawed Blind Eagle Clan|Clan de l'Aigle Aveugle aux Sept Griffes]] recomptait les délivrables des moines du temple, quand il s'aperçut qu'un moine du [[Laughing Monkey Clan|Clan du Singe Rieur]] n'avait produit aucun document de conception.
 
-« Et si on découvre un problème dans le système en production ? »
+« Et si on découvre un problème dans le système en production ? »
 demanda l'abbé au moine.
-« Comment quiconque d'autre que vous-même pourrait en comprendre la cause ? »
+« Comment quiconque d'autre que vous-même pourrait en comprendre la cause ? »
 
-« C'est le code qu'il faut examiner, » dit le moine.
-« Le Document est une bête maladive, prône à contracter l'une des Trois Plaies de l'Erreur :
-l'omission, l'obfuscation, et l'obsolescence. »
+« C'est le code qu'il faut examiner, » dit le moine.
+« Le Document est une bête maladive, prône à contracter l'une des Trois Plaies de l'Erreur :
+l'omission, l'obfuscation, et l'obsolescence. »
 
-L'abbé sigala ceci au maître Java, qui déclara :
-« Que le moine fasse le balancier sur un pied, son bâton tendu à bout de bras, chaque jour du crépuscule à muinuit.
-Je ne mettrai fin à sa punition que si il trouve un mot qui me plaise. »
+L'abbé sigala ceci au maître Java, qui déclara :
+« Que le moine fasse le balancier sur un pied, son bâton tendu à bout de bras, chaque jour du crépuscule à muinuit.
+Je ne mettrai fin à sa punition que si il trouve un mot qui me plaise. »
 
-« Existe-t-il un tel mot ? » demanda l'abbé.
+« Existe-t-il un tel mot ? » demanda l'abbé.
 
-« Difficile d'en être certain, » réfléchit le maître.
-« Hier j'ai pris plaisir au son du criquet chantant après les trois premières gouttes de pluie.
+« Difficile d'en être certain, » réfléchit le maître.
+« Hier j'ai pris plaisir au son du criquet chantant après les trois premières gouttes de pluie.
 Le jour d'avant, le clapotis du lait dans un pot me renvoya à de plaisants souvenirs de jeunesse.
-Peut-être la réponse est-elle dans le parfum d'un lotus blanc qui flottait jadis dans l'étang à ma fenêtre. »
+Peut-être la réponse est-elle dans le parfum d'un lotus blanc qui flottait jadis dans l'étang à ma fenêtre. »

--- a/the-codeless-code/fr-cdlm/case-17.txt
+++ b/the-codeless-code/fr-cdlm/case-17.txt
@@ -6,18 +6,18 @@ Translator: cdlm
 Un moine de [[Elephant's Footprint Clan|l'Emprunte d'Éléphant]] était chargé d'éliminer les montagnes de code redondant créé par son clan.
 Il approcha le prêtre en chef du clan pour savoir quelle voie suivre.
 
-« Par exemple, voici cinq manières de gérer les préférences utilisateur, »
+« Par exemple, voici cinq manières de gérer les préférences utilisateur, »
 dit le moine, étalant les pages de code sur la table.
-« Je dois soit choisir la meilleure, soit mettre en place un compromis.
-D'un côté comme de l'autre, au moins quatre modules seront jetés au feu, et leurs auteurs devrontconsommer le code d'un rival. »
+« Je dois soit choisir la meilleure, soit mettre en place un compromis.
+D'un côté comme de l'autre, au moins quatre modules seront jetés au feu, et leurs auteurs devrontconsommer le code d'un rival. »
 
-« Alors vous êtes perdu, » dit le prêtre.
-« Une fois que le chat a trempé sa patte dans la marre pour en attraper une carpe, il ne laissera pas le filet, même pour dix mille souris. »
+« Alors vous êtes perdu, » dit le prêtre.
+« Une fois que le chat a trempé sa patte dans la marre pour en attraper une carpe, il ne laissera pas le filet, même pour dix mille souris. »
 
 Le moine essuya la sueur de son front.
-« Et ce n'est qu'un parmi une douzaine de sous-systèmes redondants que je dois fusionner !
+« Et ce n'est qu'un parmi une douzaine de sous-systèmes redondants que je dois fusionner !
 Aujourd'hui j'ai vu un des frères chevronnés affûter ses couteaux à lancer.
-N'y a-t-il aucune voie qui puisse apaiser les moines de notre clan ? »
+N'y a-t-il aucune voie qui puisse apaiser les moines de notre clan ? »
 
 Le prêtre leva sa main gauche, à laquelle il manquait le petit doigt.
-« Si le chat ne peut avoir la carpe, un morceau du voleur de carpe fera office. »
+« Si le chat ne peut avoir la carpe, un morceau du voleur de carpe fera office. »

--- a/the-codeless-code/fr-cdlm/case-2.txt
+++ b/the-codeless-code/fr-cdlm/case-2.txt
@@ -1,34 +1,34 @@
-﻿Number: 2
+Number: 2
 Title: Inconnues indéterminées
-Lang:fr
+Lang: fr
 Translator: cdlm
 Illus.0.title: À la réflexion, je prendrai juste la salade.
 
 L'Empereur était irrité par les défauts dans le nouveau système de gestion des commandes qu'il avait demandé,
 il envoya donc un messager au temple pour y auditer les moines.
 
-« Son Excellence vous a envoyé ses analystes les plus éprouvés pour s'assurer que toutes les fonctionalités marcheraient comme prévu, »
+« Son Excellence vous a envoyé ses analystes les plus éprouvés pour s'assurer que toutes les fonctionalités marcheraient comme prévu, »
 annonça le messager d'un ton furieux.
-« N'avez vous compris aucune de leurs nombreuses présentations PowerPoint ? »
+« N'avez vous compris aucune de leurs nombreuses présentations PowerPoint ? »
 
-« Nous avons assisté à chacune, » dit le maître Java.
-« Et tout ce que l'on a entendu, a été compris. »
+« Nous avons assisté à chacune, » dit le maître Java.
+« Et tout ce que l'on a entendu, a été compris. »
 
 Le maître mit un petit bol de riz devant le messager, qui le finit promptement.
-Le messager s'essuya la bouche sur sa manche et continua :
+Le messager s'essuya la bouche sur sa manche et continua :
 
-« Ces mêmes analystes vous ont fourni dix mille pages de documents d'exigences,
+« Ces mêmes analystes vous ont fourni dix mille pages de documents d'exigences,
 méticuleusement illustrés jusqu'au dernier des cas d'utilisation.
-Ne vous-êtes vous pas donné la peine de les examiner ? »
+Ne vous-êtes vous pas donné la peine de les examiner ? »
 
-« Nous avons passé au crible chaque page, » dit le maître Java.
-« Et tout ce qui a été lu, a été compris. »
+« Nous avons passé au crible chaque page, » dit le maître Java.
+« Et tout ce qui a été lu, a été compris. »
 Le maître mit une tasse fumante de thé devant le messager, qui l'avala d'un trait.
 
 Le messager tomba alors en avant sur la table, mort.
 
-Le maître demanda à ses élèves :
-« Le messager ne savait-il pas que nous avons l'habitude de nous entourer de nourriture et de boissons empoisonnées,
-afin que nous puissions mieux résister aux pulsions de la chair ? »
+Le maître demanda à ses élèves :
+« Le messager ne savait-il pas que nous avons l'habitude de nous entourer de nourriture et de boissons empoisonnées,
+afin que nous puissions mieux résister aux pulsions de la chair ? »
 
-« Tout ce qui a été observé par le messager, a été compris. » déclara le plus sage des moines.
+« Tout ce qui a été observé par le messager, a été compris. » déclara le plus sage des moines.

--- a/the-codeless-code/fr-cdlm/case-3.txt
+++ b/the-codeless-code/fr-cdlm/case-3.txt
@@ -17,7 +17,7 @@ Après que le moine eut obéi, le maître écarta les robes de celui-ci et sorti
 Il en pressa fermement la pointe nue dans la poitrine du moine jusqu'à ce qu'une goutte rubis naisse autour de la lame.
 Le moine cria de terreur et demanda au maître quelle était son intention.
 
-« T'ouvrir le ventre, » expliqua le maître « de sorte que je puisse verser le riz et le thé à l'intérieur.
-Mon emploi du temps est déja bien rempli, et je trouve cette façon de nourrir les invités extrêmement efficace. »
+« T'ouvrir le ventre, » expliqua le maître « de sorte que je puisse verser le riz et le thé à l'intérieur.
+Mon emploi du temps est déja bien rempli, et je trouve cette façon de nourrir les invités extrêmement efficace. »
 
 Après cela le moine n'eut plus à être corrigé.

--- a/the-codeless-code/fr-cdlm/case-4.txt
+++ b/the-codeless-code/fr-cdlm/case-4.txt
@@ -5,17 +5,17 @@ Translator: cdlm
 
 Un nouveau prêtre du [[Spider Clan|Clan de l'Araignée]] se lamentait de la mauvaise qualité du code Javascript produit par ses novices.
 
-« Je vais enquêter », déclara le maître Java.
+« Je vais enquêter », déclara le maître Java.
 
 Après avoir visité les novices, le maître décréta que les quatre premiers devraient être frappés vivement sur les doigts chaque matin avant que leurs mains ne touchent leurs claviers.
 Pour le cinquième novice, il ne prescrit aucune action.
 Le prêtre demanda au maître pourquoi il en était ainsi.
 
-« La jeune pousse, si elle est bien soignée, peut devenir le saule, mais pas le brin d'herbe », dit le maître.
+« La jeune pousse, si elle est bien soignée, peut devenir le saule, mais pas le brin d'herbe », dit le maître.
 
 En entendant cela, le prêtre ordonna qu'on licencie le cinquième novice.
 
 À sa grande surprise, cela irrita grandement le maître Java, et le prêtre lui-même fut jeté dehors.
-Sur son dernier talon de paie, le maître écrivit ceci :
+Sur son dernier talon de paie, le maître écrivit ceci :
 
 /On ne peut pas s'allonger sur mille saules et contempler le lever du soleil./

--- a/the-codeless-code/fr-cdlm/case-5.txt
+++ b/the-codeless-code/fr-cdlm/case-5.txt
@@ -9,34 +9,34 @@ Il partit marcher seul pour s'éclaircir l'esprit.
 Bientôt, le maître se trouva face aux portes du temple des Trois Pierres, où l'art du C ANSI était toujours pratiqué.
 Un frère érudit montait la garde.
 
-« Quelle est la nature de /void/ ? » demanda le maître.
+« Quelle est la nature de /void/ ? » demanda le maître.
 
-« Ça n'a pas de nature », répondit le frère.
-« C'est le bâton que va chercher le chien qui ne va jamais chercher de bâton.  C'est la chose vers laquelle pointe le doigt qui ne pointe vers rien.  C'est la parfaite absence de valeur. »
+« Ça n'a pas de nature », répondit le frère.
+« C'est le bâton que va chercher le chien qui ne va jamais chercher de bâton.  C'est la chose vers laquelle pointe le doigt qui ne pointe vers rien.  C'est la parfaite absence de valeur. »
 
-Le maître pensa : « Le temple des Trois Pierres n'a nul besoin d'un garde. Il ne peut rien renfermer qui soit de valeur. »
+Le maître pensa : « Le temple des Trois Pierres n'a nul besoin d'un garde. Il ne peut rien renfermer qui soit de valeur. »
 
 Un peu plus loin, il arriva au temple du Ciel de Fonte Blanche, une congrégation théoricienne où seul ML était autorisé.
 Dans le jardin desséché, une religieuse était en train de tracer des lambda-expressions dans la poussière.
 
-« Quelle est la nature de /void/ ? » demanda le maître.
+« Quelle est la nature de /void/ ? » demanda le maître.
 
-« Ça a la couleur de l'air, le poids du brouillard qui se lève », répondit la sœur.
-« Quand on frappe contre, ça fait le bruit d'une nouvelle lune glissant derrière un nuage.  Chaque bol vide en contient autant que vous souhaitez. »
+« Ça a la couleur de l'air, le poids du brouillard qui se lève », répondit la sœur.
+« Quand on frappe contre, ça fait le bruit d'une nouvelle lune glissant derrière un nuage.  Chaque bol vide en contient autant que vous souhaitez. »
 
-Le maître pensa : « La sœur n'a rien dit qui soit faux, mais rien qui soit vrai non plus. »
+Le maître pensa : « La sœur n'a rien dit qui soit faux, mais rien qui soit vrai non plus. »
 
 Plus loin sur le chemin, le maître arriva devant un grand manoir, dont une vieille femme taillait les haies.
 
-« Quelle est la nature de /void/ ? » demanda le maître.
+« Quelle est la nature de /void/ ? » demanda le maître.
 
 La vieille femme salua et repris sa tâche.
 
-Le maître pensa : « Voici la plus pure sagesse, à moins que cela n'en soit que l'absence. »
+Le maître pensa : « Voici la plus pure sagesse, à moins que cela n'en soit que l'absence. »
 
 Finalement le maître arriva à un cimetière abandonné.
 
-« Quelle est la nature de /void/ ? » demanda le maître.
+« Quelle est la nature de /void/ ? » demanda le maître.
 
 De la cour vide, aucune réponse ne vint.
 

--- a/the-codeless-code/fr-cdlm/case-6.txt
+++ b/the-codeless-code/fr-cdlm/case-6.txt
@@ -10,30 +10,30 @@ Ces utilisateurs, extrêmement préoccupés, résiliaient leurs comptes après �
 Avec quelque difficulté, l'abbé remonta la trace du problème jusqu'à une méthode dont le but annoncé était de renvoyer une liste des transactions de l'utilisateur.
 En l'absence de transactions, elle renvoyait null, plutôt que la liste vide.
 
-« Amenez-moi le moine qui a écrit cette méthode », ordonna-t-il aux gardes du temple.
-« Ainsi que le moine qui l'invoque dans son code. »
+« Amenez-moi le moine qui a écrit cette méthode », ordonna-t-il aux gardes du temple.
+« Ainsi que le moine qui l'invoque dans son code. »
 
 Le premier moine, qui était l'aîné des deux, déclara que la faute en incombait clairement au second.
-« Mon Javadoc était on ne peut plus clair.
-Ça n'est pas ma faute si il n'a pas prévu les nulls. »
+« Mon Javadoc était on ne peut plus clair.
+Ça n'est pas ma faute si il n'a pas prévu les nulls. »
 Le second moine baissa la tête de honte et se tut.
 
 L'abbé frappa dans ses mains et deux hautes urnes de jade furent placées sur le sol, une devant chaque moine.
-« Vos peines sont écrites sur des morceaux de papier dedans.
-Chaque jour, vous devrez prendre le premier morceau de papier que votre main touche, et en obéir l'injonction à la lettre, jusqu'à ce que votre urne soit vide. »
+« Vos peines sont écrites sur des morceaux de papier dedans.
+Chaque jour, vous devrez prendre le premier morceau de papier que votre main touche, et en obéir l'injonction à la lettre, jusqu'à ce que votre urne soit vide. »
 
 Le plus jeune cadet fut prié de commencer.
 Sa main n'avait pas plongé à moitié dans l'urne qu'on entendit le bruissement du papier.
 Il lut le papier, s'inclina, et s'en fut.
 
 Le moine aîné passa le bras profondément dans sa propre urne jusqu'à ce que ses doigts en touchent le fond froid.
-« Il n'y a pas de papier dans cette urne » dit le moine, un sourire au coin des lèvres.
+« Il n'y a pas de papier dans cette urne » dit le moine, un sourire au coin des lèvres.
 
-« Ni de poissons, ni dix montagnes », dit l'abbé.
+« Ni de poissons, ni dix montagnes », dit l'abbé.
 
 Le moine aîné cria alors de douleur.
 L'urne bascula et éclata en morceaux.
 Un scorpion s'enfuit sur le carrelage.
 
 L'abbé considéra le moine mourant.
-« Tous les riens ne se valent pas. »
+« Tous les riens ne se valent pas. »

--- a/the-codeless-code/fr-cdlm/case-7.txt
+++ b/the-codeless-code/fr-cdlm/case-7.txt
@@ -6,33 +6,33 @@ Illus.1.title: Passée la première centaine d'années, on devient bien meilleur
 
 Les moines du [[Laughing Monkey Clan|Clan du Singe Rieur]] approchèrent le maître Java avec une liste de griefs.
 
-« Notre plus grande frustration est le processus de test », insista le plus jeune moine.
-« Tester manuellement est fastidieux, et les tests automatisés sont pénibles à écrire.
-Tous deux nous distrayent de l'écriture de code. »
+« Notre plus grande frustration est le processus de test », insista le plus jeune moine.
+« Tester manuellement est fastidieux, et les tests automatisés sont pénibles à écrire.
+Tous deux nous distrayent de l'écriture de code. »
 
-Le maître considéra ces mots, et dit :
-« Il est certain que nous pourrions renoncer entièrement aux tests,
+Le maître considéra ces mots, et dit :
+« Il est certain que nous pourrions renoncer entièrement aux tests,
 si nous avions l'assurance que notre code est parfait.
-Comment, donc, pouvons nous atteindre la perfection ? »
+Comment, donc, pouvons nous atteindre la perfection ? »
 
-« Par la pratique », dit un moine.
+« Par la pratique », dit un moine.
 
-« Par de diligentes études », dit un autre.
+« Par de diligentes études », dit un autre.
 
-« Par l'appaisement des dieux appropriés », dit un troisième.
+« Par l'appaisement des dieux appropriés », dit un troisième.
 
-Un vieux moine à la barbe blanche, qui était resté assis en silence dans son coin, releva la tête :
+Un vieux moine à la barbe blanche, qui était resté assis en silence dans son coin, releva la tête :
 
-« Je sais comment atteindre la perfection, » commença-t-il.
-« Mais je crains que quiconque entendra ma réponse doutera de sa vérité à jamais,
+« Je sais comment atteindre la perfection, » commença-t-il.
+« Mais je crains que quiconque entendra ma réponse doutera de sa vérité à jamais,
 à moins que je ne prononce exactement les bons mots,
 avec la plus agréable des intonations,
 au moment le plus propice du jour.
-Il me faut maintenant considérer comment procéder au mieux. »
+Il me faut maintenant considérer comment procéder au mieux. »
 
 Le vieux moine fit silence, longuement.
 La cloche du dîner finit par sonner.
 
-« Combien de temps cela prendra-t-il ? » s'enquérit l'un des novices.
+« Combien de temps cela prendra-t-il ? » s'enquérit l'un des novices.
 
-« Pas plus d'une centaine d'années » fut la réponse du vieux moine.
+« Pas plus d'une centaine d'années » fut la réponse du vieux moine.

--- a/the-codeless-code/fr-cdlm/case-8.txt
+++ b/the-codeless-code/fr-cdlm/case-8.txt
@@ -3,21 +3,21 @@ Title: Réduis, réutilise, recycle
 Lang: fr
 Translator: cdlm
 
-Un novice demanda au grand maître : « Quelle est la Voie ?»
+Un novice demanda au grand maître : « Quelle est la Voie ? »
 
-Le maître répondit : « L'écriture du code est la Voie »
+Le maître répondit : « L'écriture du code est la Voie »
 
-Le novice demanda alors : « Que n'est pas la Voie ? »
+Le novice demanda alors : « Que n'est pas la Voie ? »
 
-Le maître répondit : « Écrire du code n'est pas la Voie. »
+Le maître répondit : « Écrire du code n'est pas la Voie. »
 
-Le novice dit : « Alors l'écriture du code est toute chose. »
+Le novice dit : « Alors l'écriture du code est toute chose. »
 
-Le maître répondit : « Ainsi que la non-écriture du code. »
+Le maître répondit : « Ainsi que la non-écriture du code. »
 
-Le novice demanda : « En cet instant présent, sommes-nous en train d'écrire du code, ou de non-écrire du code ? »
+Le novice demanda : « En cet instant présent, sommes-nous en train d'écrire du code, ou de non-écrire du code ? »
 
-Le maître répondit : « Nous sommes le code. »
+Le maître répondit : « Nous sommes le code. »
 
 
 

--- a/the-codeless-code/fr-cdlm/case-9.txt
+++ b/the-codeless-code/fr-cdlm/case-9.txt
@@ -2,31 +2,31 @@ Number: 9
 Title: Infinités
 Lang: fr
 Translator: cdlm
-Illus.0.title: Vous pensiez être pauvre parce que vous avez dû partager vos vêtements ? Nous avons dû partager nos JAMBES.
+Illus.0.title: Vous pensiez être pauvre parce que vous avez dû partager vos vêtements ? Nous avons dû partager nos JAMBES.
 
 Deux moines du [[Spider Clan|Clan de l'Araignée]] se disputaient pour savoir si la nouvelle routine de validation des données d'entrée était tombée dans une boucle infinie.
 
-« Depuis combien de temps tourne-t-elle ? » demanda l'abbé.
+« Depuis combien de temps tourne-t-elle ? » demanda l'abbé.
 
-« Pas plus de trente minutes » dit le petit moine pâle.
+« Pas plus de trente minutes » dit le petit moine pâle.
 
-« Mais pas moins non plus » dit le gros moine bronzé.
+« Mais pas moins non plus » dit le gros moine bronzé.
 
-« Et depuis ce temps vous n'avez rien fait d'autre qu'attendre qu'elle termine ? » demanda l'abbé.
+« Et depuis ce temps vous n'avez rien fait d'autre qu'attendre qu'elle termine ? » demanda l'abbé.
 
 Les moines baissèrent la tête de honte.
 
 L'abbé fit rapport de l'incident au maître Java, qui acquiesca.
-« Lequel d'entre eux pense que la boucle n'est /pas/ infinie? »
+« Lequel d'entre eux pense que la boucle n'est /pas/ infinie ? »
 
-« Le petit pâle », dit l'abbé.
+« Le petit pâle », dit l'abbé.
 
-« Alors donnez-lui une outre de vin, car il est sage.
+« Alors donnez-lui une outre de vin, car il est sage.
 Aucune boucle ne peut être réellement infinie.
-Le jour ou l'autre l'électricié sera coupée, le serveur rouillera, le temple tombera en ruines, et le soleil engloutira la terre. »
+Le jour ou l'autre l'électricié sera coupée, le serveur rouillera, le temple tombera en ruines, et le soleil engloutira la terre. »
 
-L'abbé s'enquérit, « Et au gros bronzé, qui pense que la boucle est infinie ? »
+L'abbé s'enquérit, « Et au gros bronzé, qui pense que la boucle est infinie ? »
 
-« Donnez-lui deux outres de vin, car il est plus sage encore.
+« Donnez-lui deux outres de vin, car il est plus sage encore.
 Pour l'utilisateur attendant devant son navigateur, dix secondes sont une agonie, une minute est une vie, et tout délai au delà est pour ainsi dire une éternité.
-Quand le tigre attaque l'antilope, l'antilope ne se demande pas si c'est huit griffes ou un million qu'il utilise. »
+Quand le tigre attaque l'antilope, l'antilope ne se demande pas si c'est huit griffes ou un million qu'il utilise. »

--- a/the-codeless-code/fr-cdlm/extras/geekiness-help.txt
+++ b/the-codeless-code/fr-cdlm/extras/geekiness-help.txt
@@ -1,6 +1,6 @@
 Les degrés de geekitude
 
-Dans le but de ne pas trop frustrer le lecteur, l'auteur a classé chaque cas selon les critères suivants :
+Dans le but de ne pas trop frustrer le lecteur, l'auteur a classé chaque cas selon les critères suivants :
 
 Pas geek.
 	Si vous savez ce qu'est un ordinateur, vous pouvez probablement comprendre ceci.


### PR DESCRIPTION
This is to follow proper typography. Maybe the markup processor should take care of this, e.g. with a filter like Smartypants or Typogruby.

In french, non-breaking spaces go inside guillemot `«»` quotes, and before double punctuation signs `:;!?`
No spaces at all inside parentheses or before small punctuation like comma or period. For em-dashes, the rules are less fixed so I left them as is.
