### PR TITLE
Changed "nowincjusz" to "nowicjusz"

### DIFF
--- a/the-codeless-code/pl-badziew/case-1.txt
+++ b/the-codeless-code/pl-badziew/case-1.txt
@@ -7,9 +7,9 @@ Illus.0.title: Odpytywanie mistrza Javy dlaczego chodzenie boso jest zakazane w 
 
 Przez trzy dni i noce mistrz Javy nie opuszczał swojej izby.
 Czwartego dnia świątynni mnichowie postanowili wysłać
-jednego z nowincjuszy, aby ten dowiedział się co się stało.
+jednego z nowicjuszy, aby ten dowiedział się co się stało.
 
-Nowincjusz zastał mistrza przy tablicy, zadumanego nad diagramem przepływu
+Nowicjusz zastał mistrza przy tablicy, zadumanego nad diagramem przepływu
 danych. Rozpoznał schemat na diagramie jako jeden z pomniejszych komponentów
 dużego systemu, do zarządzania którym byli zatrudnieni mnisi. Zapytał więc
 grzecznie mistrza nad czym się tak zastanawia.
@@ -17,11 +17,11 @@ grzecznie mistrza nad czym się tak zastanawia.
 Mistrz odpowiedział://
 - Znalazłem błąd i rozmyślam nad najlepszą metodą jego naprawy.
 
-Nowincjusz odparł://
+Nowicjusz odparł://
 - Często głosisz nam kazania mistrzu, o tym jak ważne jest wyznaczanie
 odpowiednich priorytetów. Dlaczego więc zadręczasz się teraz czymś tak małym
 i mało istotnym?
 
 Mistrz bez słowa uniósł swą laskę i uderzył z całej siły w mały palec
-lewej stopy nowincjusza, łamiąc najmniejszą z jego kości. Mnich zawył z bólu
+lewej stopy nowicjusza, łamiąc najmniejszą z jego kości. Mnich zawył z bólu
 i odkuśtykał z celi mistrza. I tak oto doznał oświecenia.


### PR DESCRIPTION
Polish equivalent for "novice" is "nowicjusz", not "nowincjusz" - there is no such word in Polish vocabulary.
References: https://translate.google.pl/#en/pl/novice, http://en.wikipedia.org/wiki/Novice -> http://pl.wikipedia.org/wiki/Nowicjusz