### PR TITLE
One Shoe Clan - FR - Clan N'a Qu'Un Soulier - fix

### DIFF
--- a/the-codeless-code/fr-abelards/One+Shoe+Clan.txt
+++ b/the-codeless-code/fr-abelards/One+Shoe+Clan.txt
@@ -1,9 +1,9 @@
 Name: One Shoe Clan
 Lang: fr
 Translator: abelards
-Title: Le Clan N'a Qu'Une Chaussure
+Title: Le Clan N'a Qu'Un Soulier
 
-L'endroit où tout le Temple passe demander des hacks d'une minute et des solutions temporaires.
+L'endroit où tout le Temple passe demander des hacks à la minute et des solutions temporaires.
 Nommés ainsi car un homme avec une seule chaussure peut toujours traverser un lit de charbons
 ardents sans se brûler, en sautillant...
 Ça n'est peut-être pas joli, ça ne dure peut-être pas longtemps, mais ça marche.


### PR DESCRIPTION
The title is a homage to Uderzo's Oumpah-Pah and its single-toothed character "N'a Qu'Une Dent".
I feel the title somehow reflects the unbalanced feeling you should get when dealing with the One Shoe Clan.