### PR TITLE
Error in formatting fixed.

### DIFF
--- a/the-codeless-code/de-andrebogus/case-191.txt
+++ b/the-codeless-code/de-andrebogus/case-191.txt
@@ -39,11 +39,8 @@ Selbstverletzung hindert!'"
 
 Der Mönch sagte, "Ihr spracht nur drei Worte.  Was ist das Vierte?"
 
-Bawan drückte den /Aus/-Knopf und ging.
+Bawan drückte den <i>Aus</i>-Knopf und ging.
 
 
 
-{{*}} Anm. des Übersetzers: Das Wort ist eigentlich eine 
-Fehlübersetzung, wie mir ein Informatikprofessor einst deutlich zu
-verstehen gab: "Wenn Sie eine Benutzerschnittstelle haben, dann haben
-Sie sich geschnitten!"
+{{*}} Anm. des Übersetzers: Das Wort ist eigentlich eine Fehlübersetzung, wie mir ein Informatikprofessor vor vielen Jahren deutlich zu verstehen gab: "Wenn Sie eine Benutzerschnittstelle haben, dann haben Sie sich geschnitten!"


### PR DESCRIPTION
I found that the page did not display /Aus/ as <i>Aus</i>, so I replaced it with the direct HTML code (hoping that it will display correctly). Also the translator's annotation was cut short on display. Removing the line breaks will hopefully help.