### PR TITLE
Fix the Three Virtues link

### DIFF
--- a/the-codeless-code/de-andrebogus/case-206.txt
+++ b/the-codeless-code/de-andrebogus/case-206.txt
@@ -69,5 +69,5 @@ Erneut kam die prompte Antwort innerhalb von Sekunden:
       Schreibt erneut, und Ihr wisst, was ich meine.
 
 
-{{*}} Von einem der Patriarchen genannt: <a href="http://threevirtues.com">Faulheit, Ungeduld, und Selbstüberschätzung</a>.
+{{*}} Von einem der Patriarchen genannt: <a href="https://thethreevirtues.com">Faulheit, Ungeduld, und Selbstüberschätzung</a>.
 

--- a/the-codeless-code/en-qi/case-206.txt
+++ b/the-codeless-code/en-qi/case-206.txt
@@ -73,6 +73,6 @@ Again, within seconds he received a reply:
 
 
 
-{{*}} Declared by one of the Patriarchs to be: <a href="http://threevirtues.com">laziness, impatience, and hubris</a>.
+{{*}} Declared by one of the Patriarchs to be: <a href="https://thethreevirtues.com">laziness, impatience, and hubris</a>.
 
 

--- a/the-codeless-code/fr-abelards/case-206.txt
+++ b/the-codeless-code/fr-abelards/case-206.txt
@@ -66,4 +66,4 @@ De nouveau, il reçut une réponse quelques secondes plus tard :
       et il décidera alors de coder une base de réponses automatiques. //
       Si vous lisez ceci, veuillez reformuler et renvoyer votre question.
 
-{{*}} Qui sont, selon l'un des Patriarches, <a href="http://threevirtues.com">la paresse, l'impatience et l'hubris</a>.
+{{*}} Qui sont, selon l'un des Patriarches, <a href="https://thethreevirtues.com">la paresse, l'impatience et l'hubris</a>.


### PR DESCRIPTION
The original Three Virtues website http://threevirtues.com/ is down. The domain was taken over. The webstie was restored from the Wayback Machine at https://thethreevirtues.com/.

I'm not sure about this fix; perhaps we should use the Wayback Machine link instead? https://web.archive.org/web/20211014194234/http://threevirtues.com/